### PR TITLE
Support additive subscriptions after initial RealtimeClient connection

### DIFF
--- a/auraxis/examples/realtime.rs
+++ b/auraxis/examples/realtime.rs
@@ -31,7 +31,7 @@ async fn main() -> Result<(), Box<dyn Error>> {
 
     let mut client = RealtimeClient::new(config);
 
-    client.subscribe(subscription);
+    client.subscribe(subscription).await;
 
     let mut events = client.connect().await?;
 


### PR DESCRIPTION
This PR allows one to additive-ly subscribe after the initial websocket connection. The main changes are
- Change `RealtimeClient`'s `subscription_config` type `Arc<SubscriptionSettings>` -> `Arc<Mutex<SubscriptionSettings>>`
- Make `RealtimeClient.subscribe()` async
- Send a subscription message down the WS when `RealtimeClient.subscribe()` is called

Technically `subscription_config` will only hold the `SubscriptionSettings` from the most recent `subscribe()` call, instead of the "sum" of all previous subs - would need to add some way to merge the previous settings with the new one, but I don't need that for my purposes.

I'm still new to Rust so lmk if you'd like any changes here :)

This will close #7 