### PR TITLE
Implement getFaction for Loadout

### DIFF
--- a/auraxis/src/constants.rs
+++ b/auraxis/src/constants.rs
@@ -33,6 +33,38 @@ pub enum Loadout {
     NSMAX = 45,
 }
 
+impl Loadout {
+    fn getFaction(&self) -> Faction {
+        match self {
+            Loadout::Unknown => Faction::Unknown,
+            Loadout::NCInfiltrator => Faction::NC,
+            Loadout::NCLightAssault => Faction::NC,
+            Loadout::NCMedic => Faction::NC,
+            Loadout::NCEngineer => Faction::NC,
+            Loadout::NCHeavyAssault => Faction::NC,
+            Loadout::NCMAX => Faction::NC,
+            Loadout::TRInfiltrator => Faction::TR,
+            Loadout::TRLightAssault => Faction::TR,
+            Loadout::TRMedic => Faction::TR,
+            Loadout::TREngineer => Faction::TR,
+            Loadout::TRHeavyAssault => Faction::TR,
+            Loadout::TRMAX => Faction::TR,
+            Loadout::VSInfiltrator => Faction::VS,
+            Loadout::VSLightAssault => Faction::VS,
+            Loadout::VSMedic => Faction::VS,
+            Loadout::VSEngineer => Faction::VS,
+            Loadout::VSHeavyAssault => Faction::VS,
+            Loadout::VSMAX => Faction::VS,
+            Loadout::NSInfiltrator => Faction::NS,
+            Loadout::NSLightAssault => Faction::NS,
+            Loadout::NSMedic => Faction::NS,
+            Loadout::NSEngineer => Faction::NS,
+            Loadout::NSHeavyAssault => Faction::NS,
+            Loadout::NSMAX => Faction::NS,
+        }
+    }
+}
+
 impl FromStr for Loadout {
     type Err = anyhow::Error;
 

--- a/auraxis/src/constants.rs
+++ b/auraxis/src/constants.rs
@@ -34,7 +34,7 @@ pub enum Loadout {
 }
 
 impl Loadout {
-    fn getFaction(&self) -> Faction {
+    pub fn getFaction(&self) -> Faction {
         match self {
             Loadout::Unknown => Faction::Unknown,
             Loadout::NCInfiltrator => Faction::NC,

--- a/auraxis/src/constants.rs
+++ b/auraxis/src/constants.rs
@@ -34,7 +34,7 @@ pub enum Loadout {
 }
 
 impl Loadout {
-    pub fn getFaction(&self) -> Faction {
+    pub fn get_faction(&self) -> Faction {
         match self {
             Loadout::Unknown => Faction::Unknown,
             Loadout::NCInfiltrator => Faction::NC,


### PR DESCRIPTION
This PR will implement a way to get a faction from a loadout. In a lot of situations this can be the only way to get the faction from an event.
I am not entirely sure if there is a better way to implement this besides grabbing this info from Census/Lithafalcon in a macro. Though I am all ears to re-implement it in a better way.