### PR TITLE
Reconnecting stream

### DIFF
--- a/auraxis/Cargo.toml
+++ b/auraxis/Cargo.toml
@@ -24,7 +24,7 @@ reqwest = { version = "0.11.12", default-features = false, features = ["json", "
 async-trait = "0.1.58"
 auraxis_macros = { version = "0.1.0", path = "../auraxis_macros", optional = true }
 metrics = "0.21.0"
-stream-reconnect = "0.3.4"
+stream-reconnect = "0.4.0-beta.4"
 
 [dev-dependencies]
 tracing-subscriber = "0.3"


### PR DESCRIPTION
This PR should enable a reconnecting version of the realtime client. However I would suggest not merging yet as I will do some testing first. I'll keep a connection running like this for some time unless you have better suggestions to test reconnects.